### PR TITLE
Split UI into multiple pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# round-robin-soccer-tournament
-testing a website that takes the scores of soccer teams for our Six-A-Side tournament
+# Round Robin Soccer Tournament
+
+This small project helps record scores for a Six-A-Side soccer tournament. The app is now split into separate pages:
+
+- **Register Teams** (`register.html`) – add teams taking part.
+- **Matches** (`matches.html`) – capture match results.
+- **Scoreboard** (`scoreboard.html`) – view standings and the final matchup.
+
+Open `index.html` for links to each section. Results are stored in your browser so you can navigate between pages without losing data.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,84 +1,100 @@
 body {
-    font-family: Arial, sans-serif;
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 20px;
-    background-color: #f0f0f0;
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #f0f0f0;
 }
-h1, h2 {
-    color: #333;
-    text-align: center;
+h1,
+h2 {
+  color: #333;
+  text-align: center;
 }
-input, button, select {
-    margin: 5px 0;
-    padding: 5px;
+input,
+button,
+select {
+  margin: 5px 0;
+  padding: 5px;
 }
 table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 20px;
-    background-color: white;
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+  background-color: white;
 }
-th, td {
-    border: 1px solid #ddd;
-    padding: 8px;
-    text-align: left;
+th,
+td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
 }
 th {
-    background-color: #f2f2f2;
+  background-color: #f2f2f2;
 }
 .match-result {
-    display: flex;
-    align-items: center;
-    margin-bottom: 10px;
-    padding: 10px;
-    background-color: white;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  padding: 10px;
+  background-color: white;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 .match-result.team1-win {
-    border-left: 5px solid #4CAF50;
+  border-left: 5px solid #4caf50;
 }
 .match-result.team2-win {
-    border-left: 5px solid #2196F3;
+  border-left: 5px solid #2196f3;
 }
 .match-result.draw {
-    border-left: 5px solid #FFC107;
+  border-left: 5px solid #ffc107;
 }
 .score-input {
-    display: flex;
-    align-items: center;
-    background-color: white;
-    padding: 10px;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-    margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  background-color: white;
+  padding: 10px;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  margin-bottom: 10px;
 }
 .score-input input {
-    width: 40px;
-    text-align: center;
+  width: 40px;
+  text-align: center;
 }
 .score-input span {
-    margin: 0 10px;
+  margin: 0 10px;
 }
 .points {
-    font-weight: bold;
-    margin-left: 10px;
+  font-weight: bold;
+  margin-left: 10px;
 }
 button {
-    background-color: #4CAF50;
-    color: white;
-    border: none;
-    padding: 5px 10px;
-    border-radius: 3px;
-    cursor: pointer;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 3px;
+  cursor: pointer;
 }
 button:hover {
-    background-color: #45a049;
+  background-color: #45a049;
 }
 #teamFilter {
-    display: block;
-    margin: 20px auto;
-    padding: 10px;
-    font-size: 16px;
+  display: block;
+  margin: 20px auto;
+  padding: 10px;
+  font-size: 16px;
+}
+nav {
+  text-align: center;
+  margin-bottom: 20px;
+}
+nav a {
+  margin: 0 10px;
+  text-decoration: none;
+  color: #0066cc;
+}
+nav a:hover {
+  text-decoration: underline;
 }

--- a/index.html
+++ b/index.html
@@ -1,54 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Round Robin Soccer Tournament</title>
-    <link rel="stylesheet" href="css/styles.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-</head>
-<body>
-    <h1>Round Robin Soccer Tournament</h1>
-    
-    <h2>Team Registration</h2>
-    <input type="text" id="teamName" placeholder="Enter team name">
-    <button onclick="addTeam()">Add Team</button>
-    <ul id="teamList"></ul>
-    
-    <h2>Matches</h2>
-    <div id="matches"></div>
-    
-    <h2>Match Results</h2>
-    <select id="teamFilter" onchange="filterMatches()">
-        <option value="">All Teams</option>
-    </select>
-    <div id="matchResults"></div>
-    
-    <h2>Scoreboard</h2>
-    <table id="scoreboard">
-        <thead>
-            <tr>
-                <th>Team</th>
-                <th>Played</th>
-                <th>Goal Wins</th>
-                <th>Corner Wins</th>
-                <th>Drawn</th>
-                <th>Lost</th>
-                <th>Goals For</th>
-                <th>Goals Against</th>
-                <th>Goal Difference</th>
-                <th>Points</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-    
-    <h2>Positions</h2>
-    <div id="positions"></div>
-    
-    <h2>Final</h2>
-    <div id="final"></div>
-
-    <script src="js/script.js"></script>
-</body>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="register.html">Register Teams</a> |
+      <a href="matches.html">Matches</a> |
+      <a href="scoreboard.html">Scoreboard</a>
+    </nav>
+    <h1>Welcome to the Tournament Manager</h1>
+    <p>
+      Use the links above to register teams, record match results and view the
+      scoreboard.
+    </p>
+  </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -2,66 +2,89 @@ let teams = [];
 let matches = [];
 let scoreboard = {};
 
+function loadData() {
+  const data = JSON.parse(localStorage.getItem("tournamentData")) || {};
+  teams = data.teams || [];
+  matches = data.matches || [];
+  scoreboard = data.scoreboard || {};
+}
+
+function saveData() {
+  localStorage.setItem(
+    "tournamentData",
+    JSON.stringify({ teams, matches, scoreboard }),
+  );
+}
+
+function displayTeams() {
+  const list = $("#teamList");
+  if (!list.length) return;
+  list.empty();
+  teams.forEach((team) => list.append(`<li>${team}</li>`));
+}
+
 function addTeam() {
-    const teamName = $('#teamName').val().trim();
-    console.log(`Adding team: ${teamName}`); // Debug log
-    if (teamName && !teams.includes(teamName)) {
-        teams.push(teamName);
-        scoreboard[teamName] = {
-            played: 0,
-            goalWins: 0,
-            cornerWins: 0,
-            drawn: 0,
-            lost: 0,
-            goalsFor: 0,
-            goalsAgainst: 0,
-            points: 0
-        };
-        $('#teamList').append(`<li>${teamName}</li>`);
-        $('#teamName').val('');
-        updateTeamFilter();
-        generateMatches();
-        updateScoreboard();
-    } else {
-        console.log(`Team not added. Either the name is empty or the team already exists.`);
-    }
+  const teamName = $("#teamName").val().trim();
+  if (teamName && !teams.includes(teamName)) {
+    teams.push(teamName);
+    scoreboard[teamName] = {
+      played: 0,
+      goalWins: 0,
+      cornerWins: 0,
+      drawn: 0,
+      lost: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+      points: 0,
+    };
+    $("#teamName").val("");
+    displayTeams();
+    updateTeamFilter();
+    generateMatches();
+    updateScoreboard();
+    saveData();
+  }
 }
 
 function updateTeamFilter() {
-    const filter = $('#teamFilter');
-    filter.empty();
-    filter.append('<option value="">All Teams</option>');
-    teams.forEach(team => {
-        filter.append(`<option value="${team}">${team}</option>`);
-    });
+  const filter = $("#teamFilter");
+  if (!filter.length) return;
+  filter.empty();
+  filter.append('<option value="">All Teams</option>');
+  teams.forEach((team) => {
+    filter.append(`<option value="${team}">${team}</option>`);
+  });
 }
 
 function generateMatches() {
-    matches = [];
-    for (let i = 0; i < teams.length; i++) {
-        for (let j = i + 1; j < teams.length; j++) {
-            matches.push({
-                team1: teams[i],
-                team2: teams[j],
-                played: false,
-                goals1: 0,
-                goals2: 0,
-                corners1: 0,
-                corners2: 0,
-                points1: 0,
-                points2: 0
-            });
-        }
+  matches = [];
+  for (let i = 0; i < teams.length; i++) {
+    for (let j = i + 1; j < teams.length; j++) {
+      matches.push({
+        team1: teams[i],
+        team2: teams[j],
+        played: false,
+        goals1: 0,
+        goals2: 0,
+        corners1: 0,
+        corners2: 0,
+        points1: 0,
+        points2: 0,
+      });
     }
-    displayMatches();
-    displayMatchResults();
+  }
+  saveData();
+  displayMatches();
+  displayMatchResults();
 }
 
 function displayMatches() {
-    let matchesHtml = '';
-    matches.forEach((match, index) => {
-        if (!match.played) {
-            matchesHtml += `
+  const container = $("#matches");
+  if (!container.length) return;
+  let matchesHtml = "";
+  matches.forEach((match, index) => {
+    if (!match.played) {
+      matchesHtml += `
                 <div class="score-input">
                     <span>${match.team1}</span>
                     <input type="number" id="goals1_${index}" placeholder="Goals" min="0">
@@ -73,31 +96,37 @@ function displayMatches() {
                     <button onclick="submitMatch(${index})">Submit</button>
                 </div>
             `;
-        }
-    });
-    $('#matches').html(matchesHtml);
+    }
+  });
+  container.html(matchesHtml);
 }
 
 function filterMatches() {
-    const selectedTeam = $('#teamFilter').val();
-    displayMatchResults(selectedTeam);
+  const selectedTeam = $("#teamFilter").val();
+  displayMatchResults(selectedTeam);
 }
 
-function displayMatchResults(filterTeam = '') {
-    let resultsHtml = '';
-    matches.forEach((match, index) => {
-        if (!filterTeam || match.team1 === filterTeam || match.team2 === filterTeam) {
-            let resultClass = '';
-            if (match.played) {
-                if (match.points1 > match.points2) {
-                    resultClass = 'team1-win';
-                } else if (match.points2 > match.points1) {
-                    resultClass = 'team2-win';
-                } else {
-                    resultClass = 'draw';
-                }
-            }
-            resultsHtml += `
+function displayMatchResults(filterTeam = "") {
+  const container = $("#matchResults");
+  if (!container.length) return;
+  let resultsHtml = "";
+  matches.forEach((match, index) => {
+    if (
+      !filterTeam ||
+      match.team1 === filterTeam ||
+      match.team2 === filterTeam
+    ) {
+      let resultClass = "";
+      if (match.played) {
+        if (match.points1 > match.points2) {
+          resultClass = "team1-win";
+        } else if (match.points2 > match.points1) {
+          resultClass = "team2-win";
+        } else {
+          resultClass = "draw";
+        }
+      }
+      resultsHtml += `
                 <div class="match-result ${resultClass}">
                     ${match.team1} ${match.goals1} - ${match.goals2} ${match.team2}
                     (Corners: ${match.corners1} - ${match.corners2})
@@ -105,28 +134,28 @@ function displayMatchResults(filterTeam = '') {
                     <button onclick="editMatch(${index})">Edit</button>
                 </div>
             `;
-        }
-    });
-    $('#matchResults').html(resultsHtml);
+    }
+  });
+  container.html(resultsHtml);
 }
 
 function submitMatch(index) {
-    const match = matches[index];
-    const goals1 = parseInt($(`#goals1_${index}`).val()) || 0;
-    const corners1 = parseInt($(`#corners1_${index}`).val()) || 0;
-    const goals2 = parseInt($(`#goals2_${index}`).val()) || 0;
-    const corners2 = parseInt($(`#corners2_${index}`).val()) || 0;
+  const goals1 = parseInt($(`#goals1_${index}`).val()) || 0;
+  const corners1 = parseInt($(`#corners1_${index}`).val()) || 0;
+  const goals2 = parseInt($(`#goals2_${index}`).val()) || 0;
+  const corners2 = parseInt($(`#corners2_${index}`).val()) || 0;
 
-    updateMatchResult(index, goals1, corners1, goals2, corners2);
-    displayMatches();
-    filterMatches();
-    updateScoreboard();
-    checkTournamentEnd();
+  updateMatchResult(index, goals1, corners1, goals2, corners2);
+  displayMatches();
+  filterMatches();
+  updateScoreboard();
+  checkTournamentEnd();
+  saveData();
 }
 
 function editMatch(index) {
-    const match = matches[index];
-    $('#matches').html(`
+  const match = matches[index];
+  $("#matches").html(`
         <div class="score-input">
             <span>${match.team1}</span>
             <input type="number" id="goals1_${index}" value="${match.goals1}" min="0">
@@ -141,81 +170,120 @@ function editMatch(index) {
 }
 
 function updateMatch(index) {
-    const goals1 = parseInt($(`#goals1_${index}`).val()) || 0;
-    const corners1 = parseInt($(`#corners1_${index}`).val()) || 0;
-    const goals2 = parseInt($(`#goals2_${index}`).val()) || 0;
-    const corners2 = parseInt($(`#corners2_${index}`).val()) || 0;
+  const goals1 = parseInt($(`#goals1_${index}`).val()) || 0;
+  const corners1 = parseInt($(`#corners1_${index}`).val()) || 0;
+  const goals2 = parseInt($(`#goals2_${index}`).val()) || 0;
+  const corners2 = parseInt($(`#corners2_${index}`).val()) || 0;
 
-    updateMatchResult(index, goals1, corners1, goals2, corners2);
-    displayMatches();
-    filterMatches();
-    updateScoreboard();
-    checkTournamentEnd();
+  updateMatchResult(index, goals1, corners1, goals2, corners2);
+  displayMatches();
+  filterMatches();
+  updateScoreboard();
+  checkTournamentEnd();
+  saveData();
 }
 
 function updateMatchResult(index, goals1, corners1, goals2, corners2) {
-    const match = matches[index];
-    
-    // If the match was already played, subtract the old stats
-    if (match.played) {
-        updateTeamStats(match.team1, -match.goals1, -match.goals2, -match.corners1, -match.corners2, -match.points1, true);
-        updateTeamStats(match.team2, -match.goals2, -match.goals1, -match.corners2, -match.corners1, -match.points2, true);
-    }
+  const match = matches[index];
 
-    // Update match data
-    match.goals1 = goals1;
-    match.corners1 = corners1;
-    match.goals2 = goals2;
-    match.corners2 = corners2;
-    match.played = true;
+  if (match.played) {
+    updateTeamStats(
+      match.team1,
+      -match.goals1,
+      -match.goals2,
+      -match.corners1,
+      -match.corners2,
+      -match.points1,
+      true,
+    );
+    updateTeamStats(
+      match.team2,
+      -match.goals2,
+      -match.goals1,
+      -match.corners2,
+      -match.corners1,
+      -match.points2,
+      true,
+    );
+  }
 
-    // Calculate points
-    if (goals1 > goals2) {
-        match.points1 = 3;
-        match.points2 = 0;
-    } else if (goals2 > goals1) {
-        match.points1 = 0;
-        match.points2 = 3;
+  match.goals1 = goals1;
+  match.corners1 = corners1;
+  match.goals2 = goals2;
+  match.corners2 = corners2;
+  match.played = true;
+
+  if (goals1 > goals2) {
+    match.points1 = 3;
+    match.points2 = 0;
+  } else if (goals2 > goals1) {
+    match.points1 = 0;
+    match.points2 = 3;
+  } else {
+    if (corners1 > corners2) {
+      match.points1 = 2;
+      match.points2 = 0;
+    } else if (corners2 > corners1) {
+      match.points1 = 0;
+      match.points2 = 2;
     } else {
-        if (corners1 > corners2) {
-            match.points1 = 2;
-            match.points2 = 0;
-        } else if (corners2 > corners1) {
-            match.points1 = 0;
-            match.points2 = 2;
-        } else {
-            match.points1 = 1;
-            match.points2 = 1;
-        }
+      match.points1 = 1;
+      match.points2 = 1;
     }
+  }
 
-    // Add the new stats
-    updateTeamStats(match.team1, goals1, goals2, corners1, corners2, match.points1);
-    updateTeamStats(match.team2, goals2, goals1, corners2, corners1, match.points2);
+  updateTeamStats(
+    match.team1,
+    goals1,
+    goals2,
+    corners1,
+    corners2,
+    match.points1,
+  );
+  updateTeamStats(
+    match.team2,
+    goals2,
+    goals1,
+    corners2,
+    corners1,
+    match.points2,
+  );
 }
 
-function updateTeamStats(team, goalsFor, goalsAgainst, corners, opponentCorners, points, isEdit = false) {
-    const stats = scoreboard[team];
-    if (!isEdit) stats.played += 1;
-    stats.goalsFor += goalsFor;
-    stats.goalsAgainst += goalsAgainst;
-    stats.points += points;
+function updateTeamStats(
+  team,
+  goalsFor,
+  goalsAgainst,
+  corners,
+  opponentCorners,
+  points,
+  isEdit = false,
+) {
+  const stats = scoreboard[team];
+  if (!isEdit) stats.played += 1;
+  stats.goalsFor += goalsFor;
+  stats.goalsAgainst += goalsAgainst;
+  stats.points += points;
 
-    if (points === 3) {
-        stats.goalWins += 1;
-    } else if (points === 2) {
-        stats.cornerWins += 1;
-    } else if (points === 0) {
-        stats.lost += 1;
-    } else {
-        stats.drawn += 1;
-    }
+  if (points === 3) {
+    stats.goalWins += 1;
+  } else if (points === 2) {
+    stats.cornerWins += 1;
+  } else if (points === 0) {
+    stats.lost += 1;
+  } else {
+    stats.drawn += 1;
+  }
 }
 
 function updateScoreboard() {
-    let scoreboardHtml = '';
-    Object.entries(scoreboard).sort((a, b) => b[1].points - a[1].points).forEach(([team, stats]) => {
-        scoreboardHtml += `
+  const table = $("#scoreboard tbody");
+  if (!table.length) return;
+  let scoreboardHtml = "";
+  Object.entries(scoreboard)
+    .sort((a, b) => b[1].points - a[1].points)
+    .forEach(([team, stats]) => {
+      scoreboardHtml += `
             <tr>
                 <td>${team}</td>
                 <td>${stats.played}</td>
@@ -230,26 +298,40 @@ function updateScoreboard() {
             </tr>
         `;
     });
-    $('#scoreboard tbody').html(scoreboardHtml);
+  table.html(scoreboardHtml);
 }
 
 function checkTournamentEnd() {
-    if (matches.every(match => match.played)) {
-        const sortedTeams = Object.entries(scoreboard).sort((a, b) => b[1].points - a[1].points);
-        const finalists = sortedTeams.slice(0, 2);
-        $('#final').html(`
+  if (matches.length && matches.every((match) => match.played)) {
+    const sortedTeams = Object.entries(scoreboard).sort(
+      (a, b) => b[1].points - a[1].points,
+    );
+    const finalists = sortedTeams.slice(0, 2);
+    $("#final").html(`
             <h3>Final Match</h3>
             <p>${finalists[0][0]} vs ${finalists[1][0]}</p>
         `);
-        displayPositions(sortedTeams);
-    }
+    displayPositions(sortedTeams);
+  }
 }
 
 function displayPositions(sortedTeams) {
-    let positionsHtml = '<ol>';
-    sortedTeams.forEach(([team, stats]) => {
-        positionsHtml += `<li>${team}</li>`;
-    });
-    positionsHtml += '</ol>';
-    $('#positions').html(positionsHtml);
+  const container = $("#positions");
+  if (!container.length) return;
+  let positionsHtml = "<ol>";
+  sortedTeams.forEach(([team]) => {
+    positionsHtml += `<li>${team}</li>`;
+  });
+  positionsHtml += "</ol>";
+  container.html(positionsHtml);
 }
+
+$(document).ready(function () {
+  loadData();
+  displayTeams();
+  updateTeamFilter();
+  displayMatches();
+  displayMatchResults();
+  updateScoreboard();
+  checkTournamentEnd();
+});

--- a/matches.html
+++ b/matches.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Match Entry</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  </head>
+  <body>
+    <nav>
+      <a href="register.html">Register Teams</a> |
+      <a href="matches.html">Matches</a> |
+      <a href="scoreboard.html">Scoreboard</a>
+    </nav>
+    <h1>Round Robin Soccer Tournament</h1>
+
+    <h2>Matches</h2>
+    <div id="matches"></div>
+
+    <h2>Match Results</h2>
+    <select id="teamFilter" onchange="filterMatches()">
+      <option value="">All Teams</option>
+    </select>
+    <div id="matchResults"></div>
+
+    <script src="js/script.js"></script>
+    <script>
+      $(document).ready(function () {
+        loadData();
+        updateTeamFilter();
+        displayMatches();
+        filterMatches();
+      });
+    </script>
+  </body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Team Registration</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  </head>
+  <body>
+    <nav>
+      <a href="register.html">Register Teams</a> |
+      <a href="matches.html">Matches</a> |
+      <a href="scoreboard.html">Scoreboard</a>
+    </nav>
+    <h1>Round Robin Soccer Tournament</h1>
+
+    <h2>Team Registration</h2>
+    <input type="text" id="teamName" placeholder="Enter team name" />
+    <button onclick="addTeam()">Add Team</button>
+    <ul id="teamList"></ul>
+
+    <script src="js/script.js"></script>
+    <script>
+      $(document).ready(function () {
+        loadData();
+        displayTeams();
+      });
+    </script>
+  </body>
+</html>

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scoreboard</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  </head>
+  <body>
+    <nav>
+      <a href="register.html">Register Teams</a> |
+      <a href="matches.html">Matches</a> |
+      <a href="scoreboard.html">Scoreboard</a>
+    </nav>
+    <h1>Round Robin Soccer Tournament</h1>
+
+    <h2>Scoreboard</h2>
+    <table id="scoreboard">
+      <thead>
+        <tr>
+          <th>Team</th>
+          <th>Played</th>
+          <th>Goal Wins</th>
+          <th>Corner Wins</th>
+          <th>Drawn</th>
+          <th>Lost</th>
+          <th>Goals For</th>
+          <th>Goals Against</th>
+          <th>Goal Difference</th>
+          <th>Points</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2>Positions</h2>
+    <div id="positions"></div>
+
+    <h2>Final</h2>
+    <div id="final"></div>
+
+    <script src="js/script.js"></script>
+    <script>
+      $(document).ready(function () {
+        loadData();
+        updateScoreboard();
+        checkTournamentEnd();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- split the existing single page into `register.html`, `matches.html` and `scoreboard.html`
- add a simple `index.html` with navigation links
- persist tournament data in `localStorage`
- enhance styling with a navigation bar
- update README with new workflow

## Testing
- `npm ci` *(fails: package-lock missing)*
- `npm test` *(fails: cannot find package.json)*
- `npx eslint .` *(fails: no ESLint config)*
- `npx prettier --write index.html register.html matches.html scoreboard.html css/styles.css js/script.js`
- `npx prettier --check index.html register.html matches.html scoreboard.html css/styles.css js/script.js`
- `npx tsc -p .` *(fails: tsconfig.json missing)*
- `npm audit --audit-level=high` *(fails: no lockfile)*
- `codespell -q 3 --skip="./.git"` *(fails: command not found)*
- `lychee --no-progress index.html register.html matches.html scoreboard.html README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419001b06483309dec540585281d62